### PR TITLE
Type checking & unused vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,12 @@ This will update your package.json automatically.
 
 Add the following scripts to your package.json
 
+Note: You must not have a `files` key defined in your `tsconfig.json` or your globs will be ignored.
+
 ```json
 {
   "scripts": {
-    "lint": "tslint 'src/**/*.{ts,tsx}' 'tests/**/*.{ts,tsx}'"
+    "lint": "tslint --project tsconfig.json --type-check 'src/**/*.{ts,tsx}' 'tests/**/*.{ts,tsx}'"
   }
 }
 ```

--- a/base/tslint.json
+++ b/base/tslint.json
@@ -32,6 +32,9 @@
     "switch-default": 2,
     "eofline": 2,
 
-    "no-var-keyword": 2
+    "no-var-keyword": 2,
+    "no-unused-expression": 2,
+    "no-unused-variable": 2,
+    "no-use-before-declare": 2
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tslint-config-dabapps",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "DabApps ESLint Configuration",
   "main": "tslint.json",
   "dependencies": {


### PR DESCRIPTION
* Add rules for unused vars & expressions
* By using the `--type-check` flag, we can also add a lot more rules that are only supported with this flag