### PR TITLE
Turn off object-literal-sort-keys

### DIFF
--- a/base/tslint.json
+++ b/base/tslint.json
@@ -35,6 +35,9 @@
     "no-var-keyword": 2,
     "no-unused-expression": 2,
     "no-unused-variable": 2,
-    "no-use-before-declare": 2
+    "no-use-before-declare": 2,
+
+    // turn off from recommended rules
+    "object-literal-sort-keys": false,
   }
 }


### PR DESCRIPTION
Turns off the rule that forces you to alphabetise the keys in an
object, as many of us feel it is a time waster.