### PR TITLE
Turn off max classes per file

### DIFF
--- a/base/tslint.json
+++ b/base/tslint.json
@@ -37,6 +37,7 @@
     "no-unused-variable": 2,
     "no-use-before-declare": 2,
 
+    "max-classes-per-file": false,
     "object-literal-sort-keys": false
   }
 }


### PR DESCRIPTION
Will be picked up on in code review, sometimes it is useful
to have a file containing two small related classes