### PR TITLE
Major update

### DIFF
--- a/base/tslint.json
+++ b/base/tslint.json
@@ -1,44 +1,81 @@
+
 {
-  "extends": [
-    "tslint:recommended",
-    "tslint-eslint-rules"
-  ],
+  "extends": ["tslint:recommended", "tslint-eslint-rules", "tslint-react"],
   "rules": {
-    "ter-indent": [2, 2, { "SwitchCase": 1, "outerIIFEBody": 1, "MemberExpression": 1, "ArrayExpression": 1, "ObjectExpression": 1 }],
-    "quotemark": [2, "single"],
-    "linebreak-style": 2,
-    "semicolon": [2, "always"],
-    "ter-max-len": [2, 120, 2, { "ignoreComments": true } ],
-    "indent": [2, "spaces"],
-    "trailing-comma": [2, {"multiline": "never", "singleline": "never"}],
+    "quotemark": [true, "single", "jsx-double", "avoid-template"],
+    "linebreak-style": [true, "LF"],
+    "semicolon": [true, "always", "ignore-interfaces"],
+    "max-line-length": [true, 120],
+    "indent": [true, "spaces"],
+    "align": [
+      true,
+      "arguments",
+      "elements",
+      "members",
+      "parameters",
+      "statements"
+    ],
+    "trailing-comma": [
+      true,
+      {
+        "multiline": {
+          "arrays": "always",
+          "objects": "always",
+          "functions": "never",
+          "imports": "always",
+          "exports": "always",
+          "typeLiterals": "always"
+        },
+        "singleline": {
+          "arrays": "never",
+          "objects": "never",
+          "functions": "never",
+          "imports": "never",
+          "exports": "never",
+          "typeLiterals": "never"
+        },
+        "esSpecCompliant": true
+      }
+    ],
     "space-before-function-paren": [2, "always"],
-
-    "triple-equals": 2,
-    "no-constant-condition": 2,
-    "no-console": 2,
-    "no-debugger": 2,
-    "no-extra-boolean-cast": 2,
-    "no-irregular-whitespace": 2,
-    "no-multi-spaces": 2,
-    "no-consecutive-blank-lines": 2,
-    "no-eval": 2,
-    "no-shadowed-variable": 2,
-    "no-trailing-whitespace": 2,
-    "no-extra-semi": 2,
-
-    "radix": 2,
-    "curly": 2,
-    "no-switch-case-fall-through": 2,
-    "switch-default": 2,
-    "eofline": 2,
-
-    "no-var-keyword": 2,
-    "no-unused-expression": 2,
-    "no-unused-variable": 2,
-    "no-use-before-declare": 2,
+    "strict-type-predicates": true,
 
     "object-literal-sort-keys": false,
-    
-    "interface-name": false
+    "interface-name": false,
+
+    "triple-equals": true,
+    "no-constant-condition": true,
+    "no-console": true,
+    "no-debugger": true,
+    "no-extra-boolean-cast": true,
+    "no-irregular-whitespace": true,
+    "no-multi-spaces": true,
+    "no-consecutive-blank-lines": true,
+    "no-eval": true,
+    "no-shadowed-variable": true,
+    "no-trailing-whitespace": true,
+    "no-extra-semi": true,
+
+    "radix": true,
+    "curly": true,
+    "no-switch-case-fall-through": true,
+    "switch-default": true,
+    "eofline": true,
+
+    "no-var-keyword": true,
+    "no-unused-expression": true,
+    "no-unused-variable": true,
+    "no-use-before-declare": true,
+
+    "jsx-alignment": true,
+    "jsx-boolean-value": [true, "never"],
+    "jsx-equals-spacing": [true, "never"],
+    "jsx-key": true,
+    "jsx-no-bind": true,
+    "jsx-no-lambda": true,
+    "jsx-no-multiline-js": true,
+    "jsx-no-string-ref": true,
+    "jsx-self-close": true,
+    "jsx-wrap-multiline": true
   }
 }

--- a/base/tslint.json
+++ b/base/tslint.json
@@ -71,8 +71,6 @@
     "jsx-boolean-value": [true, "never"],
     "jsx-equals-spacing": [true, "never"],
     "jsx-key": true,
-    "jsx-no-bind": true,
-    "jsx-no-lambda": true,
     "jsx-no-multiline-js": true,
     "jsx-no-string-ref": true,
     "jsx-self-close": true,

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "tslint-react": "3.2.0"
   },
   "devDependencies": {
+    "jsonlint": "1.6.2",
     "tslint": "5.8.0",
     "typescript": "2.3.3"
   },
@@ -16,6 +17,8 @@
     "tslint": ">=5.8.x <6.x.x"
   },
   "scripts": {
+    "jsonlint": "find . -path ./node_modules -prune -o -type f -name '*.json' -exec jsonlint -q '{}' \\;",
+    "tslint": "tslint --project 'ts/tsconfig.json' 'ts/**/*.{ts,tsx}'",
     "test": "npm run jsonlint && npm run tslint"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -4,15 +4,15 @@
   "description": "DabApps ESLint Configuration",
   "main": "tslint.json",
   "dependencies": {
-    "tslint-eslint-rules": "4.0.0"
+    "tslint-eslint-rules": "4.0.0",
   },
   "devDependencies": {
-    "tslint": "5.1.0",
-    "typescript": "2.2.2"
+    "tslint": "5.8.0",
+    "typescript": "2.3.3"
   },
   "peerDependencies": {
-    "typescript": ">=2.x.x <3.x.x",
-    "tslint": ">=5.x.x <6.x.x"
+    "typescript": ">=2.3.3 <3.x.x",
+    "tslint": ">=5.8.x <6.x.x"
   },
   "scripts": {
     "test": "npm run jsonlint && npm run tslint"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tslint-config-dabapps",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "DabApps ESLint Configuration",
   "main": "tslint.json",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "tslint.json",
   "dependencies": {
     "tslint-eslint-rules": "4.0.0",
+    "tslint-react": "3.2.0"
   },
   "devDependencies": {
     "tslint": "5.8.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,11 @@
     "tslint-react": "3.2.0"
   },
   "devDependencies": {
+    "@types/react": "16.0.19",
+    "@types/react-dom": "16.0.2",
     "jsonlint": "1.6.2",
+    "react": "16.0.0",
+    "react-dom": "16.0.0",
     "tslint": "5.8.0",
     "typescript": "2.3.3"
   },

--- a/ts/index.tsx
+++ b/ts/index.tsx
@@ -1,0 +1,34 @@
+type ReactElement = string;
+type Tag = 'div' | 'span' | 'ul' | 'ol' | 'li';
+
+interface StringIndexedObject {
+  [index: string]: any;
+}
+
+const formatProps = (props: StringIndexedObject) => {
+  return Object.keys(props)
+    .map((key) => `${key}=${props[key]}`)
+    .join(' ');
+};
+
+const React = {
+  createElement: (
+    tag: string,
+    props?: StringIndexedObject,
+    ...children: ReactElement[]
+  ) => `<${tag}${children ? undefined : '/'}>${children}${children ? `</${tag}>` : undefined}`,
+};
+
+interface Interface {
+  render(): string;
+}
+
+class Thing implements Interface {
+  public render() {
+    return React.createElement(
+      'div',
+      { foo: 'bar' },
+      React.createElement('span')
+    );
+  }
+}

--- a/ts/index.tsx
+++ b/ts/index.tsx
@@ -1,34 +1,24 @@
-type ReactElement = string;
-type Tag = 'div' | 'span' | 'ul' | 'ol' | 'li';
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 
-interface StringIndexedObject {
-  [index: string]: any;
+interface ChildProps {
+  name: string;
 }
 
-const formatProps = (props: StringIndexedObject) => {
-  return Object.keys(props)
-    .map((key) => `${key}=${props[key]}`)
-    .join(' ');
-};
+const Child = ({name}: ChildProps) => (
+  <p>
+    Hello, {name}!
+  </p>
+);
 
-const React = {
-  createElement: (
-    tag: string,
-    props?: StringIndexedObject,
-    ...children: ReactElement[]
-  ) => `<${tag}${children ? undefined : '/'}>${children}${children ? `</${tag}>` : undefined}`,
-};
-
-interface Interface {
-  render(): string;
-}
-
-class Thing implements Interface {
+class Test extends React.Component {
   public render() {
-    return React.createElement(
-      'div',
-      { foo: 'bar' },
-      React.createElement('span')
+    return (
+      <div className="test" style={{width: 100}}>
+        <Child name="World" />
+      </div>
     );
   }
 }
+
+ReactDOM.render(<Test />, document.getElementById('test'));

--- a/ts/tsconfig.json
+++ b/ts/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "strictNullChecks": true,
+    "noImplicitAny": true,
+    "pretty": true,
+    "jsx": "react",
+    "target": "es5"
+  }
+}


### PR DESCRIPTION
### Changes

* Update tslint
* Update typescript
* Test config json
* Test config rules
* Add tslint-react
* Fix a bunch of rules
* Add some react / jsx rules

### New rules

```json
    "align": [
      true,
      "arguments",
      "elements",
      "members",
      "parameters",
      "statements"
    ],
    "trailing-comma": [
      true,
      {
        "multiline": {
          "arrays": "always",
          "objects": "always",
          "functions": "never",
          "imports": "always",
          "exports": "always",
          "typeLiterals": "always"
        },
        "singleline": {
          "arrays": "never",
          "objects": "never",
          "functions": "never",
          "imports": "never",
          "exports": "never",
          "typeLiterals": "never"
        },
        "esSpecCompliant": true
      }
    ],
    "strict-type-predicates": true,
```

* strict-type-predicates - Warns for type predicates that are always true or always false. Works for ‘typeof’ comparisons to constants (e.g. ‘typeof foo === “string”’), and equality comparison to ‘null’/’undefined’. (TypeScript won’t let you compare ‘1 === 2’, but it has an exception for ‘1 === undefined’.) Does not yet work for ‘instanceof’. Does not warn for ‘if (x.y)’ where ‘x.y’ is always truthy. For that, see strict-boolean-expressions.

### JSX rules

* jsx-alignment - Enforces a consistent style for multiline JSX elements which promotes ease of editing via line-wise manipulations as well as maintainabilty via small diffs when changes are made
* jsx-boolean-value - disallow `prop={true}` syntax in favour of `prop` syntax
* jsx-equals-spacing - `prop="value"` rather than `prop = "value"`
* jsx-key - Warn about missing `key` prop in mapped elements
* jsx-no-bind - Disallows bind in the render method
* jsx-no-lambda - Disallows far arrows in the render method
* jsx-no-multiline-js - Disallows multiline JS expressions inside JSX blocks to promote readability
* jsx-no-string-ref - Allow only functions in the `ref`
* jsx-self-close - Enforces that JSX elements with no children are self-closing
* jsx-wrap-multiline - Enforces that multiline JSX expressions are wrapped with parentheses