### PR TITLE
Loosen TypeScript peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "typescript": "2.3.3"
   },
   "peerDependencies": {
-    "typescript": ">=2.3.3 <3.x.x",
-    "tslint": ">=5.8.x <6.x.x"
+    "typescript": ">= 2",
+    "tslint": ">= 5.8.x < 6.x.x"
   },
   "scripts": {
     "prettier": "prettier --write 'ts/**/*.ts?(x)'",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tslint-config-dabapps",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "DabApps ESLint Configuration",
   "main": "tslint.json",
   "dependencies": {


### PR DESCRIPTION
Currently we get complaints if using TypeScript 3, but we should just allow anything greater than TS 2 until we know that it will not work with certain versions