### PR TITLE
Latest typescript support

### DIFF
--- a/base/tslint.json
+++ b/base/tslint.json
@@ -67,7 +67,6 @@
 
     "no-var-keyword": true,
     "no-unused-expression": true,
-    "no-use-before-declare": true,
 
     "jsx-alignment": true,
     "jsx-boolean-value": [true, "never"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tslint-config-dabapps",
-  "version": "0.5.5",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "typescript": "^3.3.4000"
   },
   "peerDependencies": {
-    "typescript": ">= 2",
+    "typescript": ">= 2.9",
     "tslint": ">= 5.8.x < 6.x.x"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tslint-config-dabapps",
-  "version": "0.5.5",
+  "version": "0.6.0",
   "description": "DabApps TSLint Configuration",
   "main": "tslint.json",
   "scripts": {


### PR DESCRIPTION
Remove support for TypeScript versions below 2.9. This includes removing a deprecated eslint rule.